### PR TITLE
add scm information to top-level pom

### DIFF
--- a/src/main/resources/archetype-resources/messages/pom.xml
+++ b/src/main/resources/archetype-resources/messages/pom.xml
@@ -18,9 +18,7 @@
     </scm>
     <properties>
         <wagon-ssh.version>2.10</wagon-ssh.version>
-        <properties>
-            <jacoco.outputDir>${project.basedir}/../target/jacoco</jacoco.outputDir>
-        </properties>
+        <jacoco.outputDir>${project.basedir}/../target/jacoco</jacoco.outputDir>
     </properties>
     <build>
         <finalName>messages</finalName>

--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -7,7 +7,11 @@
     <version>${version}</version>
     <packaging>pom</packaging>
     <name>${artifactId} service (restful reBuy)</name>
-    <url>http://maven.apache.org</url>
+    <url>https://github.com/rebuy-de/CHANGEME</url>
+    <scm>
+        <developerConnection>scm:git:git@github.com:rebuy-de/CHANGEME.git</developerConnection>
+        <tag>HEAD</tag>
+    </scm>
     <modules>
         <module>messages</module>
         <module>web</module>


### PR DESCRIPTION
This PR adds the `scm`-tag to the top-level pom so that the derived silos can be released using the maven-release-plugin.

@peterpunch @rebuy-de/it-outbound 