### PR TITLE
Fix silo final name. Add "-silo" suffix.

### DIFF
--- a/src/main/resources/archetype-resources/silo/pom.xml
+++ b/src/main/resources/archetype-resources/silo/pom.xml
@@ -257,7 +257,7 @@
         </dependency>
     </dependencies>
     <build>
-        <finalName>${project.parent.artifactId}</finalName>
+        <finalName>${project.parent.artifactId}-${project.artifactId}</finalName>
         <plugins>
             <plugin>
                 <groupId>com.mysema.maven</groupId>


### PR DESCRIPTION
We used the archetype for our new silo https://github.com/rebuy-de/blue-order-import-silo.
The resulting filed missed the -"silo" suffix.

This PR adds the suffix by adding the project.artifactId (silo) to the finalName.

@rebuy-de/it-platform 
@peterpunch 