### PR TITLE
enforce UTF8 as JVM charset

### DIFF
--- a/src/main/resources/archetype-resources/silo/src/main/java/silo/Application.java
+++ b/src/main/resources/archetype-resources/silo/src/main/java/silo/Application.java
@@ -8,12 +8,18 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 
+import java.nio.charset.Charset;
+
 @SpringBootApplication
 @EnableConfigurationProperties
 public class Application
 {
     public static void main(String[] args)
     {
+        if (!Charset.forName("UTF-8").equals(Charset.defaultCharset())) {
+            throw new RuntimeException("Default charset must be UTF-8");
+        }
+
         new SpringApplicationBuilder()
             .bannerMode(Banner.Mode.OFF)
             .sources(Application.class)


### PR DESCRIPTION
We need to ensure, that everything we do with strings is `UTF8`. Since it is hard to specify the encoding of every component (ie H2, Hibernate, JAXB, ...), it is easier just to set the default charset for the JVM to `UTF8`. To be safe, that the correct charset was chosen, we just add a check for this.