### PR TITLE
Remove @DirtiesContext from BaseIntegrationTest

### DIFF
--- a/src/main/resources/archetype-resources/silo/src/test/java/silo/BaseIntegrationTest.java
+++ b/src/main/resources/archetype-resources/silo/src/test/java/silo/BaseIntegrationTest.java
@@ -11,7 +11,6 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.SpringApplicationConfiguration;
 import org.springframework.boot.test.WebIntegrationTest;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -23,7 +22,6 @@ import org.springframework.web.context.WebApplicationContext;
 @WebIntegrationTest(
     value = {"spring.profiles.active=testing"}
 )
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 public abstract class BaseIntegrationTest
 {
     @Autowired


### PR DESCRIPTION
@rebuy-de/prp-rebuy-silo-archetype 
@rebuy-de/it-outbound 

@DirtiesContext is evil in BaseClasses 