### PR TITLE
Set silo final name to parent.artifactId

### DIFF
--- a/src/main/resources/archetype-resources/silo/pom.xml
+++ b/src/main/resources/archetype-resources/silo/pom.xml
@@ -257,7 +257,7 @@
         </dependency>
     </dependencies>
     <build>
-        <finalName>${project.parent.artifactId}-${project.artifactId}</finalName>
+        <finalName>${project.parent.artifactId}</finalName>
         <plugins>
             <plugin>
                 <groupId>com.mysema.maven</groupId>


### PR DESCRIPTION
@rebuy-de/it-outbound 
@rebuy-de/prp-rebuy-silo-archetype 

I don't want to fail here again ...
aka "we change it to `${project.parent.artifactId}` anyways"