### PR TITLE
Fix test configuration for consul

### DIFF
--- a/src/main/resources/archetype-resources/silo/src/test/java/silo/configuration/ClientTestConfiguration.java
+++ b/src/main/resources/archetype-resources/silo/src/test/java/silo/configuration/ClientTestConfiguration.java
@@ -3,6 +3,7 @@
 #set($symbol_escape='\' )
 package ${package}.${artifactId}.configuration;
 
+import com.rebuy.consul.ConsulService;
 import com.rebuy.library.security.client.PermissionClient;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -25,5 +26,11 @@ public class ClientTestConfiguration
     public PermissionClient permissionClient()
     {
         return mock(PermissionClient.class);
+    }
+
+    @Bean
+    public ConsulService consulService()
+    {
+        return mock(ConsulService.class);
     }
 }


### PR DESCRIPTION
Consul-Service-Mock missing in the archetype leading to errors on the first test run.

Want to fix this

@rebuy-de/it-outbound 
@rebuy-de/prp-rebuy-silo-archetype 