### PR TITLE
fix naming issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,13 +10,13 @@
 
     <groupId>com.rebuy.archetypes</groupId>
     <artifactId>rebuy-silo-archetype</artifactId>
-    <version>5.0.3</version>
+    <version>5.0.4-SNAPSHOT</version>
     <packaging>maven-archetype</packaging>
     <name>rebuy-silo-archetype</name>
 
     <scm>
         <developerConnection>scm:git:git@github.com:rebuy-de/rebuy-silo-archetype.git</developerConnection>
-        <tag>rebuy-silo-archetype-5.0.3</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -10,13 +10,13 @@
 
     <groupId>com.rebuy.archetypes</groupId>
     <artifactId>rebuy-silo-archetype</artifactId>
-    <version>5.0.3-SNAPSHOT</version>
+    <version>5.0.3</version>
     <packaging>maven-archetype</packaging>
     <name>rebuy-silo-archetype</name>
 
     <scm>
         <developerConnection>scm:git:git@github.com:rebuy-de/rebuy-silo-archetype.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>rebuy-silo-archetype-5.0.3</tag>
     </scm>
 
     <properties>

--- a/src/main/resources/archetype-resources/messages/pom.xml
+++ b/src/main/resources/archetype-resources/messages/pom.xml
@@ -13,7 +13,7 @@
     <packaging>jar</packaging>
     <name>${rootArtifactId} (restful reBuy) message</name>
     <scm>
-        <developerConnection>scm:git:git@github.com:rebuy-de/${project.artifactId}.git</developerConnection>
+        <developerConnection>scm:git:git@github.com:rebuy-de/${parent.artifactId}-silo.git</developerConnection>
         <tag>HEAD</tag>
     </scm>
     <properties>

--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -15,7 +15,7 @@
     <name>${artifactId} service (restful reBuy)</name>
 
     <scm>
-        <developerConnection>scm:git:git@github.com:rebuy-de/${artifactId}.git</developerConnection>
+        <developerConnection>scm:git:git@github.com:rebuy-de/${artifactId}-silo.git</developerConnection>
         <tag>HEAD</tag>
     </scm>
 

--- a/src/main/resources/archetype-resources/silo/pom.xml
+++ b/src/main/resources/archetype-resources/silo/pom.xml
@@ -13,7 +13,7 @@
     <packaging>jar</packaging>
     <name>${rootArtifactId} (restful reBuy) silo</name>
     <scm>
-        <developerConnection>scm:git:git@github.com:rebuy-de/${project.artifactId}.git</developerConnection>
+        <developerConnection>scm:git:git@github.com:rebuy-de/${parent.artifactId}-silo.git</developerConnection>
         <tag>HEAD</tag>
     </scm>
     <properties>
@@ -256,7 +256,7 @@
         </dependency>
     </dependencies>
     <build>
-        <finalName>silo</finalName>
+        <finalName>${project.parent.artifactId}-${artifactId}</finalName>
         <plugins>
             <plugin>
                 <groupId>com.mysema.maven</groupId>

--- a/src/main/resources/archetype-resources/silo/src/main/resources/application.yml
+++ b/src/main/resources/archetype-resources/silo/src/main/resources/application.yml
@@ -17,11 +17,11 @@ spring:
             enabled: true
             force: true
     config:
-        name: CHANGEME
+        name: ${rootArtifactId}
 
 clients:
     permissionClient:
-        clientId: ${rootArtifactId}
+        clientId: ${spring.config.name}
         secret: CHANGEME
         host: customer-silo.vg
         port: 80
@@ -38,11 +38,11 @@ permissions:
         timeunit: h
 
 remoteTokenServices:
-    clientId: ${rootArtifactId}
+    clientId: ${spring.config.name}
     secret: CHANGEME
     endpoint: customer-silo.vg
 
 consul:
-    name: ${spring.config.name}
+    name: ${spring.config.name}-silo
     agent: 192.168.33.10
     siloPort: ${server.port}

--- a/src/main/resources/archetype-resources/web/pom.xml
+++ b/src/main/resources/archetype-resources/web/pom.xml
@@ -9,12 +9,12 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>${groupId}.${rootArtifactId}</groupId>
     <artifactId>web</artifactId>
-    <name>${rootArtifactId} (restful reBuy) message</name>
+    <name>${rootArtifactId} (restful reBuy) web</name>
     <packaging>jar</packaging>
     <version>${version}</version>
 
     <scm>
-        <developerConnection>scm:git:git@github.com:rebuy-de/${project.artifactId}.git</developerConnection>
+        <developerConnection>scm:git:git@github.com:rebuy-de/${parent.artifactId}-silo.git</developerConnection>
         <tag>HEAD</tag>
     </scm>
 


### PR DESCRIPTION
We do not want the "-silo" suffix everywhere, therefore have to generate a silo from the archetype using a artifact name without "-silo" suffix and add the suffix at numerous other locations.
This is obviously problematic if you do not want a suffix added. Unfortunately maven does not allow empty properties. So making the suffix configurable through an additional property during silo generation from archetype does not work either. Generating a silo which should not end with "-silo" requires manual deletion of the added "-silo" suffix.

I personally think we should reconsider our naming policy e.g. generate the silo using it's full name, with any suffixes you want to have and don't have exceptions here and there. As long as our naming policy is as is I propose the changes done with this PR.

@rebuy-de/prp-rebuy-silo-archetype 