### PR TITLE
fix warnings for incomplete references

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,13 +10,13 @@
 
     <groupId>com.rebuy.archetypes</groupId>
     <artifactId>rebuy-silo-archetype</artifactId>
-    <version>5.0.4</version>
+    <version>5.0.5-SNAPSHOT</version>
     <packaging>maven-archetype</packaging>
     <name>rebuy-silo-archetype</name>
 
     <scm>
         <developerConnection>scm:git:git@github.com:rebuy-de/rebuy-silo-archetype.git</developerConnection>
-        <tag>rebuy-silo-archetype-5.0.4</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -10,13 +10,13 @@
 
     <groupId>com.rebuy.archetypes</groupId>
     <artifactId>rebuy-silo-archetype</artifactId>
-    <version>5.0.4-SNAPSHOT</version>
+    <version>5.0.4</version>
     <packaging>maven-archetype</packaging>
     <name>rebuy-silo-archetype</name>
 
     <scm>
         <developerConnection>scm:git:git@github.com:rebuy-de/rebuy-silo-archetype.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>rebuy-silo-archetype-5.0.4</tag>
     </scm>
 
     <properties>

--- a/src/main/resources/archetype-resources/messages/pom.xml
+++ b/src/main/resources/archetype-resources/messages/pom.xml
@@ -13,7 +13,7 @@
     <packaging>jar</packaging>
     <name>${rootArtifactId} (restful reBuy) message</name>
     <scm>
-        <developerConnection>scm:git:git@github.com:rebuy-de/${parent.artifactId}-silo.git</developerConnection>
+        <developerConnection>scm:git:git@github.com:rebuy-de/${project.parent.artifactId}-silo.git</developerConnection>
         <tag>HEAD</tag>
     </scm>
     <properties>

--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -15,7 +15,7 @@
     <name>${artifactId} service (restful reBuy)</name>
 
     <scm>
-        <developerConnection>scm:git:git@github.com:rebuy-de/${artifactId}-silo.git</developerConnection>
+        <developerConnection>scm:git:git@github.com:rebuy-de/${project.artifactId}-silo.git</developerConnection>
         <tag>HEAD</tag>
     </scm>
 

--- a/src/main/resources/archetype-resources/silo/pom.xml
+++ b/src/main/resources/archetype-resources/silo/pom.xml
@@ -13,7 +13,7 @@
     <packaging>jar</packaging>
     <name>${rootArtifactId} (restful reBuy) silo</name>
     <scm>
-        <developerConnection>scm:git:git@github.com:rebuy-de/${parent.artifactId}-silo.git</developerConnection>
+        <developerConnection>scm:git:git@github.com:rebuy-de/${project.parent.artifactId}-silo.git</developerConnection>
         <tag>HEAD</tag>
     </scm>
     <properties>
@@ -256,7 +256,7 @@
         </dependency>
     </dependencies>
     <build>
-        <finalName>${project.parent.artifactId}-${artifactId}</finalName>
+        <finalName>${project.parent.artifactId}-${project.artifactId}</finalName>
         <plugins>
             <plugin>
                 <groupId>com.mysema.maven</groupId>

--- a/src/main/resources/archetype-resources/web/pom.xml
+++ b/src/main/resources/archetype-resources/web/pom.xml
@@ -14,7 +14,7 @@
     <version>${version}</version>
 
     <scm>
-        <developerConnection>scm:git:git@github.com:rebuy-de/${parent.artifactId}-silo.git</developerConnection>
+        <developerConnection>scm:git:git@github.com:rebuy-de/${project.parent.artifactId}-silo.git</developerConnection>
         <tag>HEAD</tag>
     </scm>
 


### PR DESCRIPTION
Fixes warnings such as:
`
[WARNING] Some problems were encountered while building the effective model for com.rebuy.service.channel-distribution:messages:jar:1.0.0-SNAPSHOT
[WARNING] The expression ${parent.artifactId} is deprecated. Please use ${project.parent.artifactId} instead.
`

@rebuy-de/prp-rebuy-silo-archetype 