### PR TITLE
Disable Hibernate's autoDdl

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>com.rebuy.archetypes</groupId>
     <artifactId>rebuy-silo-archetype</artifactId>
-    <version>5.0.9-SNAPSHOT</version>
+    <version>5.0.10-SNAPSHOT</version>
     <packaging>maven-archetype</packaging>
     <name>rebuy-silo-archetype</name>
 

--- a/src/main/resources/archetype-resources/silo/src/main/resources/application-testing.yml
+++ b/src/main/resources/archetype-resources/silo/src/main/resources/application-testing.yml
@@ -2,5 +2,9 @@ spring:
     main:
         show_banner: false
 
+    jpa:
+        hibernate:
+            ddlAuto: none
+
 flyway:
     locations: classpath:db.test, classpath:db.common


### PR DESCRIPTION
Override ddlAuto configuration in test configs so that Hibernate won't kick in and leave tables creation to flyway.

Related issue: https://jira.rebuy.de/browse/TRK-44

@rebuy-de/prp-rebuy-java-sdk @rebuy-de/prp-employee-tracking-silo 