### PR TITLE
use better version of mvn failsafe plugin

### DIFF
--- a/src/main/resources/archetype-resources/silo/pom.xml
+++ b/src/main/resources/archetype-resources/silo/pom.xml
@@ -106,6 +106,12 @@
             <groupId>com.rebuy.sdk</groupId>
             <artifactId>common</artifactId>
             <version>${rebuy.common.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.rebuy.sdk</groupId>

--- a/src/main/resources/archetype-resources/silo/pom.xml
+++ b/src/main/resources/archetype-resources/silo/pom.xml
@@ -26,7 +26,7 @@
         <json-path.version>2.2.0</json-path.version>
         <junit.version>4.12</junit.version>
         <apt-maven-plugin.version>1.1.3</apt-maven-plugin.version>
-        <maven-failsafe-plugin.version>2.19</maven-failsafe-plugin.version>
+        <maven-failsafe-plugin.version>2.18.1</maven-failsafe-plugin.version>
         <maven-surefire-plugin.version>2.19</maven-surefire-plugin.version>
         <mockito.version>1.10.19</mockito.version>
         <querydsl.version>4.1.4</querydsl.version>


### PR DESCRIPTION
The 2.19 causes the tests to fail with very misleading messages. When in reality the tests should not even fail