### PR TITLE
Define UTF-8 encoding for files loaded for integration tests.

### DIFF
--- a/src/main/resources/archetype-resources/silo/pom.xml
+++ b/src/main/resources/archetype-resources/silo/pom.xml
@@ -280,7 +280,7 @@
                 <configuration>
                     <groups>${package}.${artifactId}.annotation.IntegrationTest</groups>
                     <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
-                    <argLine>${jacoco.agent.it.arg}</argLine>
+                    <argLine>-Dfile.encoding=UTF-8 ${jacoco.agent.it.arg}</argLine>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
Yesterday I had trouble with an integration test. It used @SQL to load a file with an insert statement of text containing an "ü". The component that was tested relied on that this string contained the "ü" and therefor failed the test.

This was the only solution I could find, might make sense to include it in the archetype too @rebuy-de/prp-rebuy-silo-archetype ?