### PR TITLE
Use own schema for flyway

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,13 +10,13 @@
 
     <groupId>com.rebuy.archetypes</groupId>
     <artifactId>rebuy-silo-archetype</artifactId>
-    <version>9.3.1-SNAPSHOT</version>
+    <version>9.4.0</version>
     <packaging>maven-archetype</packaging>
     <name>rebuy-silo-archetype</name>
 
     <scm>
         <developerConnection>scm:git:git@github.com:rebuy-de/rebuy-silo-archetype.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>rebuy-silo-archetype-9.4.0</tag>
     </scm>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -10,13 +10,13 @@
 
     <groupId>com.rebuy.archetypes</groupId>
     <artifactId>rebuy-silo-archetype</artifactId>
-    <version>9.4.0</version>
+    <version>9.4.1-SNAPSHOT</version>
     <packaging>maven-archetype</packaging>
     <name>rebuy-silo-archetype</name>
 
     <scm>
         <developerConnection>scm:git:git@github.com:rebuy-de/rebuy-silo-archetype.git</developerConnection>
-        <tag>rebuy-silo-archetype-9.4.0</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <properties>

--- a/src/main/resources/archetype-resources/silo/src/main/resources/application.yml
+++ b/src/main/resources/archetype-resources/silo/src/main/resources/application.yml
@@ -24,10 +24,7 @@ spring:
 
     flyway:
         locations: classpath:db/migration, classpath:db/common
-        schemas: flyway_migrations
-        table: ${flywayTableName}
-        baseline-version: "0"
-        baseline-on-migrate: true
+        schemas: ${rootArtifactId}
 
     jpa:
         open-in-view: false


### PR DESCRIPTION
Instead of using a dedicated schema for flyway, let us start using one schema per service and put the flyway table into it.

@rebuy-de/prp-rebuy-silo-archetype 