### PR TITLE
Add property for database schema name

### DIFF
--- a/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -9,6 +9,7 @@
         <requiredProperty key="newrelicLicenseKey" />
         <requiredProperty key="team" />
         <requiredProperty key="databasePassword" />
+        <requiredProperty key="databaseSchema" />
         <requiredProperty key="clientSecret" />
         <requiredProperty key="mailerRecipients" />
         <requiredProperty key="rabbitmqPassword" />

--- a/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -13,7 +13,6 @@
         <requiredProperty key="clientSecret" />
         <requiredProperty key="mailerRecipients" />
         <requiredProperty key="rabbitmqPassword" />
-        <requiredProperty key="flywayTableName" />
     </requiredProperties>
 
     <fileSets>

--- a/src/main/resources/archetype-resources/silo/src/main/resources/application.yml
+++ b/src/main/resources/archetype-resources/silo/src/main/resources/application.yml
@@ -24,7 +24,7 @@ spring:
 
     flyway:
         locations: classpath:db/migration, classpath:db/common
-        schemas: ${rootArtifactId}
+        schemas: ${databaseSchema}
 
     jpa:
         open-in-view: false
@@ -65,7 +65,7 @@ messaging:
     password:
     consumerExchange: rebuy
     publisherExchange: rebuy
-    schema-name: ${rootArtifactId}
+    schema-name: ${databaseSchema}
     queue-prefix: ${spring.application.name}
 
 management:

--- a/src/main/resources/archetype-resources/silo/src/main/resources/db/common/V1__schema_production_and_test.sql
+++ b/src/main/resources/archetype-resources/silo/src/main/resources/db/common/V1__schema_production_and_test.sql
@@ -1,3 +1,3 @@
 -- THIS IS AN EXAMPLE - THINK BEFORE YOU USE IT
--- DROP SCHEMA IF EXISTS ${rootArtifactId};
--- CREATE SCHEMA ${rootArtifactId};
+-- DROP SCHEMA IF EXISTS ${databaseSchema};
+-- CREATE SCHEMA ${databaseSchema};

--- a/src/main/resources/archetype-resources/silo/src/main/resources/db/migration/V2__production_only_changes.sql
+++ b/src/main/resources/archetype-resources/silo/src/main/resources/db/migration/V2__production_only_changes.sql
@@ -1,3 +1,3 @@
 -- THIS IS AN EXAMPLE - THINK BEFORE YOU USE IT
--- DROP SCHEMA IF EXISTS ${rootArtifactId};
--- CREATE SCHEMA ${rootArtifactId};
+-- DROP SCHEMA IF EXISTS ${databaseSchema};
+-- CREATE SCHEMA ${databaseSchema};

--- a/src/main/resources/archetype-resources/silo/src/main/resources/db/test/V3__test_only_changes.sql
+++ b/src/main/resources/archetype-resources/silo/src/main/resources/db/test/V3__test_only_changes.sql
@@ -1,3 +1,3 @@
 -- THIS IS AN EXAMPLE - THINK BEFORE YOU USE IT
--- DROP SCHEMA IF EXISTS ${rootArtifactId};
--- CREATE SCHEMA ${rootArtifactId};
+-- DROP SCHEMA IF EXISTS ${databaseSchema};
+-- CREATE SCHEMA ${databaseSchema};


### PR DESCRIPTION
Since all silos actually have a _hyphen_ in their names the _artifactId_ is not such a suitable name. Therefore I think it makes sense to ask explicitly for the database's schema name.

@rebuy-de/prp-rebuy-silo-archetype WDYT? Would there be a way to use string-replacements so we could automatically replace the hyphens in the artifactId and use it then as the database schema name? I actually couldn't find a direct way to do this. Maybe with a post-archetype script?

@wolfganghoesl fyi