### PR TITLE
Limit pool size

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,13 +10,13 @@
 
     <groupId>com.rebuy.archetypes</groupId>
     <artifactId>rebuy-silo-archetype</artifactId>
-    <version>10.3.1-SNAPSHOT</version>
+    <version>10.4.0</version>
     <packaging>maven-archetype</packaging>
     <name>rebuy-silo-archetype</name>
 
     <scm>
         <developerConnection>scm:git:git@github.com:rebuy-de/rebuy-silo-archetype.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>rebuy-silo-archetype-10.4.0</tag>
     </scm>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -10,13 +10,13 @@
 
     <groupId>com.rebuy.archetypes</groupId>
     <artifactId>rebuy-silo-archetype</artifactId>
-    <version>10.4.0</version>
+    <version>10.4.1-SNAPSHOT</version>
     <packaging>maven-archetype</packaging>
     <name>rebuy-silo-archetype</name>
 
     <scm>
         <developerConnection>scm:git:git@github.com:rebuy-de/rebuy-silo-archetype.git</developerConnection>
-        <tag>rebuy-silo-archetype-10.4.0</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <properties>

--- a/src/main/resources/archetype-resources/silo/src/main/resources/application-kubernetes.yml
+++ b/src/main/resources/archetype-resources/silo/src/main/resources/application-kubernetes.yml
@@ -6,8 +6,6 @@ server:
 spring:
     datasource:
         url: jdbc:postgresql://postgres-11.aws.rebuy.loc/rebuy
-        hikari:
-            maximum-pool-size: 5
 
 clients:
     permission-client:

--- a/src/main/resources/archetype-resources/silo/src/main/resources/application.yml
+++ b/src/main/resources/archetype-resources/silo/src/main/resources/application.yml
@@ -12,6 +12,7 @@ spring:
         password: ${databasePassword}
         hikari:
             maximum-pool-size: 3
+            minimum-idle: 1
 
     http:
         encoding:

--- a/src/main/resources/archetype-resources/silo/src/test/resources/application-testing.yml
+++ b/src/main/resources/archetype-resources/silo/src/test/resources/application-testing.yml
@@ -15,8 +15,6 @@ spring:
     datasource:
         url: jdbc:tc:postgresql:11://localhost/rebuy
         driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver
-        hikari:
-            maximum-pool-size: 10
 
 messaging:
     host: localhost


### PR DESCRIPTION
2x3 connections should be enough for everything. We have metrics and
alerts in place which should alert the application owner if this is not
enough.