### PR TITLE
Upgrade to objectmapper 1.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,13 +10,13 @@
 
     <groupId>com.rebuy.archetypes</groupId>
     <artifactId>rebuy-silo-archetype</artifactId>
-    <version>10.6.0</version>
+    <version>10.6.1-SNAPSHOT</version>
     <packaging>maven-archetype</packaging>
     <name>rebuy-silo-archetype</name>
 
     <scm>
         <developerConnection>scm:git:git@github.com:rebuy-de/rebuy-silo-archetype.git</developerConnection>
-        <tag>rebuy-silo-archetype-10.6.0</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -10,13 +10,13 @@
 
     <groupId>com.rebuy.archetypes</groupId>
     <artifactId>rebuy-silo-archetype</artifactId>
-    <version>10.5.1-SNAPSHOT</version>
+    <version>10.6.0</version>
     <packaging>maven-archetype</packaging>
     <name>rebuy-silo-archetype</name>
 
     <scm>
         <developerConnection>scm:git:git@github.com:rebuy-de/rebuy-silo-archetype.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>rebuy-silo-archetype-10.6.0</tag>
     </scm>
 
     <properties>

--- a/src/main/resources/archetype-resources/silo/pom.xml
+++ b/src/main/resources/archetype-resources/silo/pom.xml
@@ -39,7 +39,7 @@
         <rebuy.security.version>7.2.0</rebuy.security.version>
         <rebuy.security-test.version>1.0.0</rebuy.security-test.version>
         <rebuy.consul-client.version>2.3.0</rebuy.consul-client.version>
-        <rebuy.objectmapper.version>1.0.0</rebuy.objectmapper.version>
+        <rebuy.objectmapper.version>1.2.0</rebuy.objectmapper.version>
         <opentracing-starter.version>0.6.0</opentracing-starter.version>
     </properties>
     <dependencyManagement>


### PR DESCRIPTION
> This is a automatically generated PR.

Updates objectmapper to 1.2.0. Only this version is capable of handling java.util.Date with milliseconds.

@rebuy-de/prp-rebuy-silo-archetype @rebuy-de/it-platform Please review, merge & deploy.