### PR TITLE
Update jenkins-libraries to v1.23.0

### DIFF
--- a/src/main/resources/archetype-resources/Jenkinsfile
+++ b/src/main/resources/archetype-resources/Jenkinsfile
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
 
-library('jenkins-libraries@v1.19.0')
+library('jenkins-libraries@v1.23.0')
 
 springBoot2Pipeline(jdk: 'jdk11', email: '${mailerRecipients}')

--- a/src/main/resources/archetype-resources/deployment/docker/Dockerfile
+++ b/src/main/resources/archetype-resources/deployment/docker/Dockerfile
@@ -7,7 +7,7 @@ ENV HOME=/tmp
 
 RUN --mount=id=maven-cache,type=cache,target=/m2/repository,sharing=shared /build.sh
 
-FROM 074509403805.dkr.ecr.eu-west-1.amazonaws.com/java11
+FROM 074509403805.dkr.ecr.eu-west-1.amazonaws.com/java11-maven:${BASE_TAG}
 
 RUN mkdir -p /service \
  && useradd \


### PR DESCRIPTION
> This is a automatically generated PR.

Update Dockerfile and jenkins-libraries. With this change the maximum amount of dependents of the base-image-java can be limited. This ensures that jenkins is not too busy building too many java images at the same time.

@rebuy-de/prp-rebuy-silo-archetype Please review. I will then step by step merge & deploy the changes.