### PR TITLE
Update jenkins-libraries to v1.24.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,13 +10,13 @@
 
     <groupId>com.rebuy.archetypes</groupId>
     <artifactId>rebuy-silo-archetype</artifactId>
-    <version>10.9.0</version>
+    <version>10.9.1-SNAPSHOT</version>
     <packaging>maven-archetype</packaging>
     <name>rebuy-silo-archetype</name>
 
     <scm>
         <developerConnection>scm:git:git@github.com:rebuy-de/rebuy-silo-archetype.git</developerConnection>
-        <tag>rebuy-silo-archetype-10.9.0</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -10,13 +10,13 @@
 
     <groupId>com.rebuy.archetypes</groupId>
     <artifactId>rebuy-silo-archetype</artifactId>
-    <version>10.8.1-SNAPSHOT</version>
+    <version>10.9.0</version>
     <packaging>maven-archetype</packaging>
     <name>rebuy-silo-archetype</name>
 
     <scm>
         <developerConnection>scm:git:git@github.com:rebuy-de/rebuy-silo-archetype.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>rebuy-silo-archetype-10.9.0</tag>
     </scm>
 
     <properties>

--- a/src/main/resources/archetype-resources/Jenkinsfile
+++ b/src/main/resources/archetype-resources/Jenkinsfile
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
 
-library('jenkins-libraries@v1.19.0')
+library('jenkins-libraries@v1.24.0')
 
 springBoot2Pipeline(jdk: 'jdk11', email: '${mailerRecipients}')

--- a/src/main/resources/archetype-resources/deployment/docker/Dockerfile
+++ b/src/main/resources/archetype-resources/deployment/docker/Dockerfile
@@ -1,5 +1,6 @@
 # syntax=docker/dockerfile:experimental
-FROM 074509403805.dkr.ecr.eu-west-1.amazonaws.com/java11-maven AS builder
+ARG BASE_TAG=master
+FROM 074509403805.dkr.ecr.eu-west-1.amazonaws.com/java11-maven:${BASE_TAG} AS builder
 
 COPY . /project
 
@@ -7,7 +8,7 @@ ENV HOME=/tmp
 
 RUN --mount=id=maven-cache,type=cache,target=/m2/repository,sharing=shared /build.sh
 
-FROM 074509403805.dkr.ecr.eu-west-1.amazonaws.com/java11
+FROM 074509403805.dkr.ecr.eu-west-1.amazonaws.com/java11:${BASE_TAG}
 
 RUN mkdir -p /service \
  && useradd \


### PR DESCRIPTION
> This is a automatically generated PR.

Update Dockerfile and jenkins-libraries. With this change the maximum amount of parallel builds of dependents of the base-image-java can be limited. This ensures that jenkins is not too busy building too many java images at the same time.

@rebuy-de/prp-rebuy-silo-archetype Please review. I will then step by step merge & deploy the changes.