### PR TITLE
Use logstash-gelf instead of log4j2-gelf

### DIFF
--- a/src/main/resources/archetype-resources/silo/pom.xml
+++ b/src/main/resources/archetype-resources/silo/pom.xml
@@ -27,7 +27,7 @@
         <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
         <spring-security-oauth2-resource-server.version>5.7.3</spring-security-oauth2-resource-server.version>
         <spring.boot.version>2.7.2</spring.boot.version>
-        <log4j2-gelf.version>1.3.1</log4j2-gelf.version>
+        <logstash-gelf.version>1.15.0</logstash-gelf.version>
         <rebuy.common.version>15.1.0</rebuy.common.version>
         <rebuy.customer-client.version>15.0.0</rebuy.customer-client.version>
         <rebuy.instrumentation.version>1.0.0</rebuy.instrumentation.version>
@@ -126,9 +126,9 @@
             <artifactId>flyway-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.graylog2.log4j2</groupId>
-            <artifactId>log4j2-gelf</artifactId>
-            <version>${log4j2-gelf.version}</version>
+            <groupId>biz.paluch.logging</groupId>
+            <artifactId>logstash-gelf</artifactId>
+            <version>${logstash-gelf.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/src/main/resources/archetype-resources/silo/src/main/resources/kubernetes/log4j2.xml
+++ b/src/main/resources/archetype-resources/silo/src/main/resources/kubernetes/log4j2.xml
@@ -4,15 +4,18 @@
         <Console name="STDOUT" target="SYSTEM_OUT">
             <PatternLayout pattern="%d %-5p [%t] %C{2} (%F:%L) - %m%n"/>
         </Console>
-        <GELF name="gelfAppender" server="graylog2.default.svc.cluster.local" port="12201" includeExceptionCause="true" protocol="tcp">
-            <PatternLayout pattern="%logger{36} - %msg%n"/>
-            <Filters>
-                <MarkerFilter marker="FLOW" onMatch="DENY" onMismatch="NEUTRAL"/>
-                <MarkerFilter marker="EXCEPTION" onMatch="DENY" onMismatch="ACCEPT"/>
-            </Filters>
-            <KeyValuePair key="environment" value="production"/>
-            <KeyValuePair key="facility" value="${projectName}"/>
-        </GELF>
+        <Gelf name="gelfAppender"
+              ExtractStackTrace="true"
+              Facility="${projectName}"
+              FilterStackTrace="true"
+              Host="tcp:graylog2.default.svc.cluster.local"
+              IncludeFullMdc="true"
+              MaximumMessageSize="8192"
+              MdcProfiling="true"
+              Port="12201"
+              Version="1.1">
+            <Field name="environment" literal="production" />
+        </Gelf>
     </Appenders>
     <Loggers>
         <Logger name="org.springframework.integration.support.MessageBuilder" level="warn" />

--- a/src/main/resources/archetype-resources/silo/src/main/resources/vagrant/log4j2.xml
+++ b/src/main/resources/archetype-resources/silo/src/main/resources/vagrant/log4j2.xml
@@ -11,15 +11,18 @@
         <Console name="STDOUT" target="SYSTEM_OUT">
             <PatternLayout pattern="%d %-5p [%t] %C{2} (%F:%L) - %m%n"/>
         </Console>
-        <GELF name="gelfAppender" server="vagrant.cloud" port="12201" includeExceptionCause="true">
-            <PatternLayout pattern="%logger{36} - %msg%n"/>
-            <Filters>
-                <MarkerFilter marker="FLOW" onMatch="DENY" onMismatch="NEUTRAL"/>
-                <MarkerFilter marker="EXCEPTION" onMatch="DENY" onMismatch="ACCEPT"/>
-            </Filters>
-            <KeyValuePair key="environment" value="development"/>
-            <KeyValuePair key="facility" value="${projectName}"/>
-        </GELF>
+        <Gelf name="gelfAppender"
+              ExtractStackTrace="true"
+              Facility="${projectName}"
+              FilterStackTrace="true"
+              Host="vagrant.cloud"
+              IncludeFullMdc="true"
+              MaximumMessageSize="8192"
+              MdcProfiling="true"
+              Port="12201"
+              Version="1.1">
+            <Field name="environment" literal="development" />
+        </Gelf>
     </Appenders>
     <Loggers>
         <Logger name="org.springframework.integration.support.MessageBuilder" level="warn" />


### PR DESCRIPTION
The last release of the graylog appender is from 2016 and [they recommend to use logstash-gelf instead](https://github.com/graylog-labs/log4j2-gelf#deprecation-notice).

Current settings are copied from the [amqp-redelivery-silo](https://github.com/rebuy-de/amqp-redelivery-silo/blob/main/silo/src/main/resources/kubernetes/log4j2.xml)